### PR TITLE
行きたいリスト機能を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -28,9 +28,10 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'rails-i18n'
-gem 'pry-rails'
 gem 'mini_magick'
 gem 'image_processing'
+gem "devise", "~> 4.9"
+gem 'jp_prefecture'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -39,7 +40,8 @@ group :development, :test do
   gem 'erb_lint', require: false
   gem 'rspec-rails', '~> 6.0.0'
   gem 'factory_bot_rails'
-  gem 'jp_prefecture'
+  gem 'pry-rails'
+  gem 'dotenv-rails'
 end
 
 group :development do
@@ -63,5 +65,3 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
-gem "devise", "~> 4.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.1)
+    dotenv (3.1.4)
+    dotenv-rails (3.1.4)
+      dotenv (= 3.1.4)
+      railties (>= 6.1)
     erb_lint (0.6.0)
       activesupport
       better_html (>= 2.0.1)
@@ -343,6 +347,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   devise (~> 4.9)
+  dotenv-rails
   erb_lint
   factory_bot_rails
   image_processing

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -41,3 +41,8 @@ body {
   object-fit: cover;
   border: 1px solid rgba(128, 128, 128, 0.372);
 }
+
+#map {
+  width: 100%;
+  height: 40vh;
+}

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -72,3 +72,8 @@ body {
 .edit-link-col {
   width: 3rem;
 }
+
+.destinations-link:hover {
+  color: gray !important;
+  border-color: rgba(128, 128, 128, 0.925) !important;
+}

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -46,3 +46,29 @@ body {
   width: 100%;
   height: 40vh;
 }
+
+.txt-limit {
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.destinations-table {
+  width: 100%;
+  table-layout: fixed;
+}
+
+@media only screen and (min-width: 576px) {
+  .destn-name-col {
+    width: 30%;
+  }
+}
+
+.private-col {
+  width: 4rem;
+}
+
+.edit-link-col {
+  width: 3rem;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!
 
   protected
 

--- a/app/controllers/destinations_controller.rb
+++ b/app/controllers/destinations_controller.rb
@@ -47,6 +47,6 @@ class DestinationsController < ApplicationController
   private
 
   def destination_params
-    params.require(:destination).permit(:name, :note, :is_private, :latitude, :longitude, :user_id)
+    params.require(:destination).permit(:name, :address, :note, :is_private, :latitude, :longitude, :user_id)
   end
 end

--- a/app/controllers/destinations_controller.rb
+++ b/app/controllers/destinations_controller.rb
@@ -1,0 +1,52 @@
+class DestinationsController < ApplicationController
+  def index
+    @destination = Destination.all
+  end
+
+  def new
+    @destination = Destination.new
+  end
+
+  def create
+    @destination = Destination.new(destination_params)
+    if @destination.save
+      flash[:notice] = "行きたいところを登録しました。"
+      redirect_to destinations_path
+    else
+      flash.now[:alert] = "行きたいところの登録に失敗しました"
+      render "destinations/new"
+    end
+  end
+
+  def show
+    @destination = Destination.find(params[:id])
+  end
+
+  def edit
+    @destination = Destination.find(params[:id])
+  end
+
+  def update
+    @destination = Destination.find(params[:id])
+    if @destination.update(destination_params)
+      flash[:notice] = "行きたいところを更新しました。"
+      redirect_to destinations_path
+    else
+      flash.now[:alert] = "行きたいところの更新に失敗しました。"
+      render "destinations/edit"
+    end
+  end
+
+  def destroy
+    @destination = Destination.find(params[:id])
+    @destination.destroy
+    flash[:notice] = "行きたいところリストから #{@destination.name} を削除しました。"
+    redirect_to destinations_path
+  end
+
+  private
+
+  def destination_params
+    params.require(:destination).permit(:name, :note, :is_private, :latitude, :longitude, :user_id)
+  end
+end

--- a/app/controllers/destinations_controller.rb
+++ b/app/controllers/destinations_controller.rb
@@ -1,6 +1,11 @@
 class DestinationsController < ApplicationController
   def index
-    @destinations = current_user.destinations
+    if params[:category_id].present?
+      @destinations = current_user.destinations.where(category_id: params[:category_id])
+      @category = Category.find(params[:category_id])
+    else
+      @destinations = current_user.destinations
+    end
   end
 
   def new
@@ -52,6 +57,6 @@ class DestinationsController < ApplicationController
   private
 
   def destination_params
-    params.require(:destination).permit(:name, :address, :note, :is_private, :latitude, :longitude, :user_id)
+    params.require(:destination).permit(:name, :address, :note, :is_private, :latitude, :longitude, :user_id, :category_id)
   end
 end

--- a/app/controllers/destinations_controller.rb
+++ b/app/controllers/destinations_controller.rb
@@ -5,6 +5,8 @@ class DestinationsController < ApplicationController
 
   def new
     @destination = Destination.new
+    # アクションに応じてバリデーションエラーメッセージを変更
+    @new_record = true
   end
 
   def create
@@ -24,6 +26,8 @@ class DestinationsController < ApplicationController
 
   def edit
     @destination = Destination.find(params[:id])
+    # アクションに応じてバリデーションエラーメッセージを変更
+    @new_record = false
   end
 
   def update

--- a/app/controllers/destinations_controller.rb
+++ b/app/controllers/destinations_controller.rb
@@ -17,7 +17,7 @@ class DestinationsController < ApplicationController
   def create
     @destination = Destination.new(destination_params)
     if @destination.save
-      flash[:notice] = "「#{@destination.name} 」を登録しました。"
+      flash[:notice] = "「#{@destination.name}」を登録しました。"
       redirect_to destinations_path
     else
       flash.now[:alert] = "行きたいところの登録に失敗しました"
@@ -39,7 +39,7 @@ class DestinationsController < ApplicationController
   def update
     @destination = Destination.find(params[:id])
     if @destination.update(destination_params)
-      flash[:notice] = "「#{@destination.name} 」を更新しました。"
+      flash[:notice] = "「#{@destination.name}」を更新しました。"
       redirect_to destinations_path
     else
       flash.now[:alert] = "行きたいところの更新に失敗しました。"

--- a/app/controllers/destinations_controller.rb
+++ b/app/controllers/destinations_controller.rb
@@ -1,6 +1,6 @@
 class DestinationsController < ApplicationController
   def index
-    @destination = Destination.all
+    @destinations = current_user.destinations
   end
 
   def new
@@ -10,7 +10,7 @@ class DestinationsController < ApplicationController
   def create
     @destination = Destination.new(destination_params)
     if @destination.save
-      flash[:notice] = "行きたいところを登録しました。"
+      flash[:notice] = "「#{@destination.name} 」を登録しました。"
       redirect_to destinations_path
     else
       flash.now[:alert] = "行きたいところの登録に失敗しました"
@@ -29,7 +29,7 @@ class DestinationsController < ApplicationController
   def update
     @destination = Destination.find(params[:id])
     if @destination.update(destination_params)
-      flash[:notice] = "行きたいところを更新しました。"
+      flash[:notice] = "「#{@destination.name} 」を更新しました。"
       redirect_to destinations_path
     else
       flash.now[:alert] = "行きたいところの更新に失敗しました。"
@@ -40,7 +40,7 @@ class DestinationsController < ApplicationController
   def destroy
     @destination = Destination.find(params[:id])
     @destination.destroy
-    flash[:notice] = "行きたいところリストから #{@destination.name} を削除しました。"
+    flash[:notice] = "行きたいところリストから「#{@destination.name}」を削除しました。"
     redirect_to destinations_path
   end
 

--- a/app/controllers/destinations_controller.rb
+++ b/app/controllers/destinations_controller.rb
@@ -22,6 +22,7 @@ class DestinationsController < ApplicationController
 
   def show
     @destination = Destination.find(params[:id])
+    @destinations = current_user.destinations
   end
 
   def edit

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -16,6 +16,8 @@ class GroupsController < ApplicationController
 
   def show
     @group = Group.find(params[:id])
+    group_users = @group.users.includes(:destinations)
+    @visible_destinations = group_users.index_with { |user| user.destinations.where.not(is_private: true) }
   end
 
   def edit

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -6,7 +6,7 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(group_params_with_current_user)
     if @group.save
-      flash[:notice] = "グループを登録しました"
+      flash[:notice] = "「#{@group.name}」を登録しました"
       redirect_to user_path(current_user.id)
     else
       flash.now[:alert] = "グループの登録に失敗しました"
@@ -25,7 +25,7 @@ class GroupsController < ApplicationController
   def update
     @group = Group.find(params[:id])
     if @group.update(group_params_with_current_user)
-      flash[:notice] = "グループを更新しました"
+      flash[:notice] = "「#{@group.name}」を更新しました"
       redirect_to user_path(current_user.id)
     else
       flash.now[:alert] = "グループの更新に失敗しました"
@@ -36,7 +36,7 @@ class GroupsController < ApplicationController
   def destroy
     @group = Group.find(params[:id])
     @group.destroy
-    flash[:notice] = "グループを削除しました"
+    flash[:notice] = "「#{@group.name}」を削除しました"
     redirect_to user_path(current_user.id)
   end
 

--- a/app/helpers/destinations_helper.rb
+++ b/app/helpers/destinations_helper.rb
@@ -1,0 +1,2 @@
+module DestinationsHelper
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+  has_many :destinations
+end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,0 +1,3 @@
+class Destination < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,6 +1,6 @@
 class Destination < ApplicationRecord
   belongs_to :user
-  belongs_to :category
+  belongs_to :category, optional: true
 
   validate :encourage_search_on_maps
   validates :name, length: { maximum: 20 }

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,3 +1,17 @@
 class Destination < ApplicationRecord
   belongs_to :user
+
+  validate :encourage_search_on_maps
+  validates :name, length: { maximum: 20 }
+  validates :address, length: { maximum: 60 }
+
+  def encourage_search_on_maps
+    if name.blank? || address.blank? || latitude.blank? || longitude.blank?
+      if @new_record
+        errors.add(:base, "地図で場所を検索してください")
+      else
+        errors.add(:base, "場所の名前、住所は空欄にできません")
+      end
+    end
+  end
 end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -9,7 +9,7 @@ class Destination < ApplicationRecord
   def encourage_search_on_maps
     if name.blank? || address.blank? || latitude.blank? || longitude.blank?
       if @new_record
-        errors.add(:base, "地図で場所を検索してください")
+        errors.add(:base, "Googleマップで場所を検索してください。一部項目が自動入力されます。（編集可）")
       else
         errors.add(:base, "場所の名前、住所は空欄にできません")
       end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,5 +1,6 @@
 class Destination < ApplicationRecord
   belongs_to :user
+  belongs_to :category
 
   validate :encourage_search_on_maps
   validates :name, length: { maximum: 20 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_many :group_users, dependent: :destroy
   has_many :groups, through: :group_users, dependent: :destroy
+  has_many :destinations, dependent: :destroy
   has_one_attached :icon
 
   validates :name, presence: :true, length: { maximum: 15 }

--- a/app/views/destinations/edit.html.erb
+++ b/app/views/destinations/edit.html.erb
@@ -26,7 +26,7 @@
   <div class="row py-4 d-flex justify-content-center shadow-sm rounded-3 form-wrapper">
     <div class="col-10 col-sm-7 col-md-6 p-0">
       <h4 class="mb-4 fw-bold text-center">行きたいところを編集</h4>
-      <p class="text-center">マーカーを動かすと位置を微調整できます。</p>
+      <p class="text-center">マーカーを動かすと地点を微調整できます。</p>
       <%= render "shared/errors", obj: @destination %>
       <%= render "shared/destination_form", destination: @destination %>
       <%= link_to "削除", destination_path, method: :delete, data: { confirm: "本当に削除しますか？" } %>

--- a/app/views/destinations/edit.html.erb
+++ b/app/views/destinations/edit.html.erb
@@ -1,7 +1,32 @@
-<div class="container my-md-4" style="max-width: 768px;">
-  <div class="row py-3 py-md-5 d-flex justify-content-center shadow-sm rounded-3 form-wrapper">
+<div id='map'></div>
+<script>
+  let map
+  let marker
+  function initMap(){
+    geocoder = new google.maps.Geocoder()
+    map = new google.maps.Map(document.getElementById('map'), {
+      center:  {lat: <%= @destination.latitude %>, lng: <%= @destination.longitude %>},
+      zoom: 15,
+    });
+    marker = new google.maps.Marker({
+      position:  {lat: <%= @destination.latitude %>, lng: <%= @destination.longitude %>},
+      draggable: true,
+      map: map
+    });
+    // マーカーのドロップ（ドラッグ終了）時のイベント
+    google.maps.event.addListener( marker, 'dragend', function(ev){
+      document.getElementById('lat').value = ev.latLng.lat();
+      document.getElementById('lng').value = ev.latLng.lng();
+    });
+  }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['MAPS_PLATFORM_API_KEY'] %>&callback=initMap" async defer></script>
+
+<div class="container my-md-3" style="max-width: 768px;">
+  <div class="row py-4 d-flex justify-content-center shadow-sm rounded-3 form-wrapper">
     <div class="col-10 col-sm-7 col-md-6 p-0">
       <h4 class="mb-4 fw-bold text-center">行きたいところを編集</h4>
+      <p class="text-center">マーカーを動かすと位置を調整できます。</p>
       <%= render "shared/errors", obj: @destination %>
       <%= render "shared/destination_form", destination: @destination %>
     </div>

--- a/app/views/destinations/edit.html.erb
+++ b/app/views/destinations/edit.html.erb
@@ -1,0 +1,9 @@
+<div class="container my-md-4" style="max-width: 768px;">
+  <div class="row py-3 py-md-5 d-flex justify-content-center shadow-sm rounded-3 form-wrapper">
+    <div class="col-10 col-sm-7 col-md-6 p-0">
+      <h4 class="mb-4 fw-bold text-center">行きたいところを編集</h4>
+      <%= render "shared/errors", obj: @destination %>
+      <%= render "shared/destination_form", destination: @destination %>
+    </div>
+  </div>
+</div>

--- a/app/views/destinations/edit.html.erb
+++ b/app/views/destinations/edit.html.erb
@@ -26,9 +26,10 @@
   <div class="row py-4 d-flex justify-content-center shadow-sm rounded-3 form-wrapper">
     <div class="col-10 col-sm-7 col-md-6 p-0">
       <h4 class="mb-4 fw-bold text-center">行きたいところを編集</h4>
-      <p class="text-center">マーカーを動かすと位置を調整できます。</p>
+      <p class="text-center">マーカーを動かすと位置を微調整できます。</p>
       <%= render "shared/errors", obj: @destination %>
       <%= render "shared/destination_form", destination: @destination %>
+      <%= link_to "削除", destination_path, method: :delete, data: { confirm: "本当に削除しますか？" } %>
     </div>
   </div>
 </div>

--- a/app/views/destinations/index.html.erb
+++ b/app/views/destinations/index.html.erb
@@ -1,11 +1,41 @@
+<div id='map'></div>
+<script>
+  function initMap() {
+    let map = new google.maps.Map(document.getElementById('map'), {
+      center: {lat: 34.7024854, lng: 135.4959506},
+      zoom: 10,
+    });
+    let transitLayer = new google.maps.TransitLayer();
+    transitLayer.setMap(map);
+
+    <% @destinations.each do |destination| %>
+      (function() {
+        let markerLatLng = { lat: <%= destination.latitude %>, lng: <%= destination.longitude %> };
+        let marker = new google.maps.Marker({
+          position: markerLatLng,
+          map: map
+        });
+        //マーカーをクリックしたとき、詳細情報を表示
+        let infowindow = new google.maps.InfoWindow({
+          position: markerLatLng,
+          content: "<a href='<%= destination_url(destination.id) %>'><%= destination.name %></a>"
+        }); //詳細ページへのリンクを表示
+        marker.addListener('click', function() {
+          infowindow.open(map, marker);
+        });
+      })();
+    <% end %>
+  }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['MAPS_PLATFORM_API_KEY'] %>&callback=initMap" async defer></script>
+
 <div class="container-md mt-2 bg-white shadow-sm rounded-3">
   <div class="row py-2 d-flex justify-content-end">
     <div class="col-12">
-      <h4>行きたいところリスト</h4>
+      <h4>私の行きたいところリスト</h4>
       <%= link_to "目的地を登録", new_destination_path %>
-
       <table class="table table-striped mt-3">
-        <% @destination.each do |destination| %>
+        <% @destinations.each do |destination| %>
           <tr>
             <th><%= link_to destination.name, destination_path(destination.id) %></th>
             <td class="d-none d-md-block"><%= destination.note %></td>

--- a/app/views/destinations/index.html.erb
+++ b/app/views/destinations/index.html.erb
@@ -32,14 +32,16 @@
 <div class="container-md mt-2 bg-white shadow-sm rounded-3">
   <div class="row py-2 d-flex justify-content-end">
     <div class="col-12">
-      <h4>私の行きたいところリスト</h4>
+      <h4><%= current_user.name %>さんの行きたいところリスト</h4>
       <%= link_to "目的地を登録", new_destination_path %>
       <table class="table table-striped text-nowrap mt-3 destinations-table">
         <% @destinations.each do |destination| %>
           <tr>
             <th class="destn-name-col txt-limit"><%= link_to destination.name, destination_path(destination.id) %></th>
             <td class="d-none d-sm-block txt-limit"><%= destination.note.present? ? destination.note : "-" %></td>
-            <td class="private-col"><%= "非公開" if destination.is_private %></td>
+            <td class="private-col ">
+              <span class="badge bg-secondary rounded-pill"><%= "非公開" if destination.is_private %></span>
+            </td>
             <td class="edit-link-col"><%= link_to "編集", edit_destination_path(destination.id) %></td>
           </tr>
         <% end %>

--- a/app/views/destinations/index.html.erb
+++ b/app/views/destinations/index.html.erb
@@ -34,13 +34,13 @@
     <div class="col-12">
       <h4>私の行きたいところリスト</h4>
       <%= link_to "目的地を登録", new_destination_path %>
-      <table class="table table-striped mt-3">
+      <table class="table table-striped text-nowrap mt-3 destinations-table">
         <% @destinations.each do |destination| %>
           <tr>
-            <th><%= link_to destination.name, destination_path(destination.id) %></th>
-            <td class="d-none d-md-block"><%= destination.note %></td>
-            <td><%= "非公開" if destination.is_private %></td>
-            <td><%= link_to "編集", edit_destination_path(destination.id) %></td>
+            <th class="destn-name-col txt-limit"><%= link_to destination.name, destination_path(destination.id) %></th>
+            <td class="d-none d-sm-block txt-limit"><%= destination.note %></td>
+            <td class="private-col"><%= "非公開" if destination.is_private %></td>
+            <td class="edit-link-col"><%= link_to "編集", edit_destination_path(destination.id) %></td>
           </tr>
         <% end %>
       </table>

--- a/app/views/destinations/index.html.erb
+++ b/app/views/destinations/index.html.erb
@@ -38,7 +38,7 @@
         <% @destinations.each do |destination| %>
           <tr>
             <th class="destn-name-col txt-limit"><%= link_to destination.name, destination_path(destination.id) %></th>
-            <td class="d-none d-sm-block txt-limit"><%= destination.note %></td>
+            <td class="d-none d-sm-block txt-limit"><%= destination.note.present? ? destination.note : "-" %></td>
             <td class="private-col"><%= "非公開" if destination.is_private %></td>
             <td class="edit-link-col"><%= link_to "編集", edit_destination_path(destination.id) %></td>
           </tr>

--- a/app/views/destinations/index.html.erb
+++ b/app/views/destinations/index.html.erb
@@ -32,8 +32,30 @@
 <div class="container-md mt-2 bg-white shadow-sm rounded-3">
   <div class="row py-2 d-flex justify-content-end">
     <div class="col-12">
-      <h4><%= current_user.name %>さんの行きたいところリスト</h4>
-      <%= link_to "目的地を登録", new_destination_path %>
+      <div class="d-md-flex justify-content-between align-items-center gap-2 mb-3">
+        <h4 class="mb-md-0"><%= current_user.name %>さんの行きたいリスト</h4>
+        <%= form_with url: destinations_path, method: :get do |f| %>
+          <div class="d-flex justify-content-end align-items-center gap-1">
+            <%= f.collection_select(:category_id, Category.all, :id, :name, { prompt: "カテゴリーを選択" }, { class: "form-select form-select-sm w-auto" }) %>
+            <%= f.submit "絞り込む", class: "btn btn-secondary btn-sm" %>
+          </div>
+        <% end %>
+      </div>
+      <div class="d-flex justify-content-between align-items-center">
+        <%= link_to new_destination_path, class: "btn btn-primary btn-sm rounded-pill" do %>
+          <i class="bi bi-plus-circle"></i>
+          <span>新規登録</span>
+        <% end %>
+        <% if params[:category_id].present? %>
+          <div class="alert alert-info px-2 py-1 m-0">
+            <i class="bi bi-funnel-fill"></i>
+            <span>選択中：<%= @category.name %></span>
+            <%= link_to destinations_path do %>
+              <i class="bi bi-x-lg alert-link"></i>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
       <table class="table table-striped text-nowrap mt-3 destinations-table">
         <% @destinations.each do |destination| %>
           <tr>

--- a/app/views/destinations/index.html.erb
+++ b/app/views/destinations/index.html.erb
@@ -1,0 +1,19 @@
+<div class="container-md mt-2 bg-white shadow-sm rounded-3">
+  <div class="row py-2 d-flex justify-content-end">
+    <div class="col-12">
+      <h4>行きたいところリスト</h4>
+      <%= link_to "目的地を登録", new_destination_path %>
+
+      <table class="table table-striped mt-3">
+        <% @destination.each do |destination| %>
+          <tr>
+            <th><%= link_to destination.name, destination_path(destination.id) %></th>
+            <td class="d-none d-md-block"><%= destination.note %></td>
+            <td><%= "非公開" if destination.is_private %></td>
+            <td><%= link_to "編集", edit_destination_path(destination.id) %></td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/destinations/new.html.erb
+++ b/app/views/destinations/new.html.erb
@@ -55,10 +55,10 @@
       <h4 class="mb-4 fw-bold text-center">行きたいところを追加</h4>
       <%= render "shared/errors", obj: @destination %>
       <div class="d-flex">
-        <input id="address" class="form-control form-control-sm me-2" type="textbox" placeholder="場所を検索" autofocus=true>
+        <input id="address" class="form-control form-control-sm me-2" type="textbox" placeholder="まずはGoogleマップで検索！" autofocus=true>
         <input type="button" value="検 索" class="btn btn-outline-primary" onclick="codeAddress()">
       </div>
-      <p class="mt-2 mb-4">マーカーを動かすと位置を微調整できます。</p>
+      <p class="mt-2 mb-4">マーカーを動かすと地点を微調整できます。</p>
       <%= render "shared/destination_form", destination: @destination %>
     </div>
   </div>

--- a/app/views/destinations/new.html.erb
+++ b/app/views/destinations/new.html.erb
@@ -1,7 +1,62 @@
-<div class="container my-md-4" style="max-width: 768px;">
-  <div class="row py-3 py-md-5 d-flex justify-content-center shadow-sm rounded-3 form-wrapper">
+<div id='map'></div>
+<script>
+  //初期マップの設定
+  let map
+  let marker
+  function initMap(){
+    geocoder = new google.maps.Geocoder()
+    map = new google.maps.Map(document.getElementById('map'), {
+      center: {lat: 34.7024854, lng: 135.4959506},
+      zoom: 15,
+    });
+  }
+
+  //検索後のマップ作成
+  let geocoder
+  let aft
+  function codeAddress(){
+    let inputAddress = document.getElementById('address').value;
+    geocoder.geocode( { 'address': inputAddress}, function(results, status) {
+      if (status == 'OK') {
+        //マーカーが複数できないようにする
+        if (aft == true){
+            marker.setMap(null);
+        }
+        //新しくマーカーを作成する
+        map.setCenter(results[0].geometry.location);
+          marker = new google.maps.Marker({
+          map: map,
+          position: results[0].geometry.location,
+          draggable: true
+        });
+        //二度目以降か判断
+        aft = true
+        //検索時に緯度・経度・場所の名前を入力する
+        document.getElementById('lat').value = results[0].geometry.location.lat();
+        document.getElementById('lng').value = results[0].geometry.location.lng();
+        document.getElementById('name').value = inputAddress
+        // マーカーのドロップ（ドラッグ終了）時のイベント
+        google.maps.event.addListener( marker, 'dragend', function(ev){
+          document.getElementById('lat').value = ev.latLng.lat();
+          document.getElementById('lng').value = ev.latLng.lng();
+        });
+      } else {
+        alert('該当する情報が見つかりませんでした。');
+      }
+    });
+  }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['MAPS_PLATFORM_API_KEY'] %>&callback=initMap" async defer></script>
+
+<div class="container my-md-3" style="max-width: 768px;">
+  <div class="row py-4 d-flex justify-content-center shadow-sm rounded-3 form-wrapper">
     <div class="col-10 col-sm-7 col-md-6 p-0">
       <h4 class="mb-4 fw-bold text-center">行きたいところを追加</h4>
+      <div class="d-flex">
+        <input id="address" class="form-control form-control-sm me-2" type="textbox" placeholder="場所を検索" autofocus=true>
+        <input type="button" value="検 索" class="btn btn-outline-primary" onclick="codeAddress()">
+      </div>
+      <p class="mt-2">マーカーを動かすと位置を調整できます。</p>
       <%= render "shared/errors", obj: @destination %>
       <%= render "shared/destination_form", destination: @destination %>
     </div>

--- a/app/views/destinations/new.html.erb
+++ b/app/views/destinations/new.html.erb
@@ -1,0 +1,9 @@
+<div class="container my-md-4" style="max-width: 768px;">
+  <div class="row py-3 py-md-5 d-flex justify-content-center shadow-sm rounded-3 form-wrapper">
+    <div class="col-10 col-sm-7 col-md-6 p-0">
+      <h4 class="mb-4 fw-bold text-center">行きたいところを追加</h4>
+      <%= render "shared/errors", obj: @destination %>
+      <%= render "shared/destination_form", destination: @destination %>
+    </div>
+  </div>
+</div>

--- a/app/views/destinations/new.html.erb
+++ b/app/views/destinations/new.html.erb
@@ -53,12 +53,12 @@
   <div class="row py-4 d-flex justify-content-center shadow-sm rounded-3 form-wrapper">
     <div class="col-10 col-sm-7 col-md-6 p-0">
       <h4 class="mb-4 fw-bold text-center">行きたいところを追加</h4>
+      <%= render "shared/errors", obj: @destination %>
       <div class="d-flex">
         <input id="address" class="form-control form-control-sm me-2" type="textbox" placeholder="場所を検索" autofocus=true>
         <input type="button" value="検 索" class="btn btn-outline-primary" onclick="codeAddress()">
       </div>
-      <p class="mt-2">マーカーを動かすと位置を微調整できます。</p>
-      <%= render "shared/errors", obj: @destination %>
+      <p class="mt-2 mb-4">マーカーを動かすと位置を微調整できます。</p>
       <%= render "shared/destination_form", destination: @destination %>
     </div>
   </div>

--- a/app/views/destinations/new.html.erb
+++ b/app/views/destinations/new.html.erb
@@ -31,10 +31,11 @@
         });
         //二度目以降か判断
         aft = true
-        //検索時に緯度・経度・場所の名前を入力する
+        //検索時に緯度・経度・場所の名前・住所を入力する
         document.getElementById('lat').value = results[0].geometry.location.lat();
         document.getElementById('lng').value = results[0].geometry.location.lng();
-        document.getElementById('name').value = inputAddress
+        document.getElementById('name').value = inputAddress;
+        document.getElementById('address_on_map').value = results[0].formatted_address;
         // マーカーのドロップ（ドラッグ終了）時のイベント
         google.maps.event.addListener( marker, 'dragend', function(ev){
           document.getElementById('lat').value = ev.latLng.lat();
@@ -56,7 +57,7 @@
         <input id="address" class="form-control form-control-sm me-2" type="textbox" placeholder="場所を検索" autofocus=true>
         <input type="button" value="検 索" class="btn btn-outline-primary" onclick="codeAddress()">
       </div>
-      <p class="mt-2">マーカーを動かすと位置を調整できます。</p>
+      <p class="mt-2">マーカーを動かすと位置を微調整できます。</p>
       <%= render "shared/errors", obj: @destination %>
       <%= render "shared/destination_form", destination: @destination %>
     </div>

--- a/app/views/destinations/show.html.erb
+++ b/app/views/destinations/show.html.erb
@@ -1,9 +1,12 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col-4 col-xl-3 d-none d-sm-block ps-0 pe-lg-5">
-      <h2>list</h2>
-      <%= link_to "一覧へ戻る", destinations_path %>
-      <ul class="list-group list-group-flush">
+      <%= link_to destinations_path, class: "d-block m-3 text-decoration-none d-flex justify-content-between align-items-center border-bottom border-2 border-secondary text-dark link-hover" do %>
+        <i class="bi bi-arrow-left fs-5 ms-1"></i>
+        <span><span class="d-none d-md-inline-block">あなたの</span>行きたいリスト</span>
+        <span class="me-1"></span>
+      <% end %>
+      <ul class="list-group">
         <% @destinations.each do |destination| %>
           <li class="list-group-item list-group-item-action list-group-item-light<%= " active" if destination.id == @destination.id %> d-flex justify-content-between align-items-center pe-2">
             <%= link_to destination.name, destination_path(destination.id), class: (destination.id == @destination.id ? "text-white" : "text-body") %>
@@ -42,7 +45,7 @@
             <div class="col-12 p-3 p-md-4">
               <div class="d-flex justify-content-between align-items-center gap-2 mb-3">
                 <h4 class="mb-0"><%= @destination.name %></h4>
-                <% if @destination.category.present?  %>
+                <% if @destination.category.present? %>
                   <span class="text-nowrap badge bg-light text-dark p-2 border">
                     <%= @destination.category.name %>
                   </span>
@@ -56,8 +59,10 @@
                 <p>公開</p>
               <% end %>
               <%= @destination.user.name %>
-              <%= link_to "編集", edit_destination_path(@destination.id) %>
-              <%= link_to "削除", destination_path, method: :delete, data: { confirm: "本当に削除しますか？" } %>
+              <% if @destination.user.id == current_user.id %>
+                <%= link_to "編集", edit_destination_path(@destination.id) %>
+                <%= link_to "削除", destination_path, method: :delete, data: { confirm: "本当に削除しますか？" } %>
+              <% end %>
             </div>
           </div>
         </div>

--- a/app/views/destinations/show.html.erb
+++ b/app/views/destinations/show.html.erb
@@ -1,38 +1,59 @@
-<div class="container my-3" style="max-width: 768px;">
+<div class="container-fluid">
   <div class="row">
-    <div class="col-12 p-0">
-      <div id='map'></div>
-      <script>
-        let map
-        let marker
-        function initMap(){
-          geocoder = new google.maps.Geocoder()
-          map = new google.maps.Map(document.getElementById('map'), {
-            center:  {lat: <%= @destination.latitude %>, lng: <%= @destination.longitude %>},
-            zoom: 15,
-          });
-          marker = new google.maps.Marker({
-            position:  {lat: <%= @destination.latitude %>, lng: <%= @destination.longitude %>},
-            map: map
-          });
-        }
-      </script>
-      <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['MAPS_PLATFORM_API_KEY'] %>&callback=initMap" async defer></script>
+    <div class="col-4 col-xl-3 d-none d-sm-block ps-0 pe-lg-5">
+      <h2>list</h2>
+      <%= link_to "一覧へ戻る", destinations_path %>
+      <ul class="list-group list-group-flush">
+        <% @destinations.each do |destination| %>
+          <li class="list-group-item list-group-item-action list-group-item-light<%= " active" if destination.id == @destination.id %> d-flex justify-content-between align-items-center pe-2">
+            <%= link_to destination.name, destination_path(destination.id), class: (destination.id == @destination.id ? "text-white" : "text-body") %>
+            <% if destination.is_private %>
+              <span class="badge bg-secondary rounded-pill">非公開</span>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
     </div>
-  </div>
-  <div class="row py-4 d-flex justify-content-center shadow-sm rounded-3 form-wrapper">
-    <div class="col-11 p-0">
-      <h4><%= @destination.name %></h4>
-      <p class="text-secondary"><%= @destination.address %></p>
-      <%= @destination.note %>
-      <% if @destination.is_private %>
-        <p>非公開</p>
-      <% else %>
-        <p>公開</p>
-      <% end %>
-      <%= @destination.user.name %>
-      <%= link_to "編集", edit_destination_path(@destination.id) %>
-      <%= link_to "削除", destination_path, method: :delete, data: { confirm: "本当に削除しますか？" } %>
-    </div>
+    <div class="col-12 col-sm-8 col-xl-9 mt-sm-3">
+      <div class="row">
+        <div class="col-12 col-sm-11 p-0" style="max-width:800px;">
+          <div id='map'></div>
+          <script>
+            let map
+            let marker
+            function initMap(){
+              geocoder = new google.maps.Geocoder()
+              map = new google.maps.Map(document.getElementById('map'), {
+                center:  {lat: <%= @destination.latitude %>, lng: <%= @destination.longitude %>},
+                zoom: 15,
+              });
+              marker = new google.maps.Marker({
+                position:  {lat: <%= @destination.latitude %>, lng: <%= @destination.longitude %>},
+                map: map
+              });
+            }
+          </script>
+          <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['MAPS_PLATFORM_API_KEY'] %>&callback=initMap" async defer></script>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-12 col-sm-11" style="max-width:800px;">
+          <div class="row shadow-sm rounded-3 form-wrapper">
+            <div class="col-12 p-3 p-md-4">
+              <h4><%= @destination.name %></h4>
+              <p class="text-secondary"><%= @destination.address %></p>
+              <%= @destination.note %>
+              <% if @destination.is_private %>
+                <p>非公開</p>
+              <% else %>
+                <p>公開</p>
+              <% end %>
+              <%= @destination.user.name %>
+              <%= link_to "編集", edit_destination_path(@destination.id) %>
+              <%= link_to "削除", destination_path, method: :delete, data: { confirm: "本当に削除しますか？" } %>
+            </div>
+          </div>
+        </div>
+      </div>
   </div>
 </div>

--- a/app/views/destinations/show.html.erb
+++ b/app/views/destinations/show.html.erb
@@ -1,10 +1,37 @@
-<h4><%= @destination.name %></h4>
-<%= @destination.note %>
-<% if @destination.is_private %>
-  <p>非公開</p>
-<% else %>
-  <p>公開</p>
-<% end %>
-<%= @destination.user.name %>
-<%= link_to "編集", edit_destination_path(@destination.id) %>
-<%= link_to "削除", destination_path, method: :delete, data: { confirm: "本当に削除しますか？" } %>
+<div class="container my-3" style="max-width: 768px;">
+  <div class="row">
+    <div class="col-12 p-0">
+      <div id='map'></div>
+      <script>
+        let map
+        let marker
+        function initMap(){
+          geocoder = new google.maps.Geocoder()
+          map = new google.maps.Map(document.getElementById('map'), {
+            center:  {lat: <%= @destination.latitude %>, lng: <%= @destination.longitude %>},
+            zoom: 15,
+          });
+          marker = new google.maps.Marker({
+            position:  {lat: <%= @destination.latitude %>, lng: <%= @destination.longitude %>},
+            map: map
+          });
+        }
+      </script>
+      <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['MAPS_PLATFORM_API_KEY'] %>&callback=initMap" async defer></script>
+    </div>
+  </div>
+  <div class="row py-4 d-flex justify-content-center shadow-sm rounded-3 form-wrapper">
+    <div class="col-11 p-0">
+      <h4><%= @destination.name %></h4>
+      <%= @destination.note %>
+      <% if @destination.is_private %>
+        <p>非公開</p>
+      <% else %>
+        <p>公開</p>
+      <% end %>
+      <%= @destination.user.name %>
+      <%= link_to "編集", edit_destination_path(@destination.id) %>
+      <%= link_to "削除", destination_path, method: :delete, data: { confirm: "本当に削除しますか？" } %>
+    </div>
+  </div>
+</div>

--- a/app/views/destinations/show.html.erb
+++ b/app/views/destinations/show.html.erb
@@ -23,6 +23,7 @@
   <div class="row py-4 d-flex justify-content-center shadow-sm rounded-3 form-wrapper">
     <div class="col-11 p-0">
       <h4><%= @destination.name %></h4>
+      <p class="text-secondary"><%= @destination.address %></p>
       <%= @destination.note %>
       <% if @destination.is_private %>
         <p>非公開</p>

--- a/app/views/destinations/show.html.erb
+++ b/app/views/destinations/show.html.erb
@@ -1,0 +1,10 @@
+<h4><%= @destination.name %></h4>
+<%= @destination.note %>
+<% if @destination.is_private %>
+  <p>非公開</p>
+<% else %>
+  <p>公開</p>
+<% end %>
+<%= @destination.user.name %>
+<%= link_to "編集", edit_destination_path(@destination.id) %>
+<%= link_to "削除", destination_path, method: :delete, data: { confirm: "本当に削除しますか？" } %>

--- a/app/views/destinations/show.html.erb
+++ b/app/views/destinations/show.html.erb
@@ -42,9 +42,11 @@
             <div class="col-12 p-3 p-md-4">
               <div class="d-flex justify-content-between align-items-center gap-2 mb-3">
                 <h4 class="mb-0"><%= @destination.name %></h4>
-                <span class="text-nowrap badge bg-light text-dark p-2 border">
-                  <%= @destination.category.name if @destination.category.present? %>
-                </span>
+                <% if @destination.category.present?  %>
+                  <span class="text-nowrap badge bg-light text-dark p-2 border">
+                    <%= @destination.category.name %>
+                  </span>
+                <% end %>
               </div>
               <p class="text-secondary"><%= @destination.address %></p>
               <%= @destination.note %>

--- a/app/views/destinations/show.html.erb
+++ b/app/views/destinations/show.html.erb
@@ -1,7 +1,7 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col-4 col-xl-3 d-none d-sm-block ps-0 pe-lg-5">
-      <%= link_to destinations_path, class: "d-block m-3 text-decoration-none d-flex justify-content-between align-items-center border-bottom border-2 border-secondary text-dark link-hover" do %>
+      <%= link_to destinations_path, class: "d-block m-3 text-decoration-none d-flex justify-content-between align-items-center border-bottom border-2 border-secondary text-dark destinations-link" do %>
         <i class="bi bi-arrow-left fs-5 ms-1"></i>
         <span><span class="d-none d-md-inline-block">あなたの</span>行きたいリスト</span>
         <span class="me-1"></span>

--- a/app/views/destinations/show.html.erb
+++ b/app/views/destinations/show.html.erb
@@ -40,7 +40,12 @@
         <div class="col-12 col-sm-11" style="max-width:800px;">
           <div class="row shadow-sm rounded-3 form-wrapper">
             <div class="col-12 p-3 p-md-4">
-              <h4><%= @destination.name %></h4>
+              <div class="d-flex justify-content-between align-items-center gap-2 mb-3">
+                <h4 class="mb-0"><%= @destination.name %></h4>
+                <span class="text-nowrap badge bg-light text-dark p-2 border">
+                  <%= @destination.category.name if @destination.category.present? %>
+                </span>
+              </div>
               <p class="text-secondary"><%= @destination.address %></p>
               <%= @destination.note %>
               <% if @destination.is_private %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -7,3 +7,14 @@
 <%= link_to "編集", edit_group_path(@group.id) %>
 <%= link_to "グループを削除", group_path, method: :delete, data: { confirm: "本当に削除しますか？" } %>
 <%= link_to "マイページ", user_path(current_user.id) %>
+
+<% @visible_destinations.each do |user, destinations| %>
+  <h5><%= user.name %></h5>
+  <ul>
+    <% destinations.each do |destination| %>
+      <li>
+        <%= link_to destination.name, destination_path(destination.id) %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/shared/_destination_form.html.erb
+++ b/app/views/shared/_destination_form.html.erb
@@ -1,0 +1,28 @@
+<%= form_with model: destination do |f| %>
+  <div class="mb-3">
+    <%= f.label :name %>
+    <%= f.text_field :name, autofocus: true, class: "form-control form-control-sm" %>
+  </div>
+  <div class="mb-3">
+    <%= f.label :note %>
+    <%= f.text_area :note, class: "form-control form-control-sm" %>
+  </div>
+  <div class="mb-3">
+    <%= f.label :latitude %>
+    <%= f.text_field :latitude, class: "form-control form-control-sm" %>
+  </div>
+  <div class="mb-3">
+    <%= f.label :longitude %>
+    <%= f.text_field :longitude, class: "form-control form-control-sm" %>
+  </div>
+  <div class="mb-3 form-check">
+    <%= f.check_box :is_private, {class: "form-check-input"}, "true", "false" %>
+    <%= f.label :is_private, "非公開にする場合はチェック", class: "form-check-label" %>
+  </div>
+  <div>
+    <%= f.hidden_field :user_id, value: current_user.id %>
+  </div>
+  <div class="mb-3 d-grid gap-2">
+    <%= f.submit '保存', class: "btn btn-danger rounded-pill" %>
+  </div>
+<% end %>

--- a/app/views/shared/_destination_form.html.erb
+++ b/app/views/shared/_destination_form.html.erb
@@ -1,28 +1,20 @@
 <%= form_with model: destination do |f| %>
-  <div class="mb-3">
+  <div class="mb-2">
     <%= f.label :name %>
-    <%= f.text_field :name, autofocus: true, class: "form-control form-control-sm" %>
+    <%= f.text_field :name, id: :name, class: "form-control form-control-sm" %>
   </div>
-  <div class="mb-3">
+  <div class="mb-2">
     <%= f.label :note %>
     <%= f.text_area :note, class: "form-control form-control-sm" %>
   </div>
-  <div class="mb-3">
-    <%= f.label :latitude %>
-    <%= f.text_field :latitude, class: "form-control form-control-sm" %>
-  </div>
-  <div class="mb-3">
-    <%= f.label :longitude %>
-    <%= f.text_field :longitude, class: "form-control form-control-sm" %>
-  </div>
-  <div class="mb-3 form-check">
+  <div class="mb-2 form-check">
     <%= f.check_box :is_private, {class: "form-check-input"}, "true", "false" %>
     <%= f.label :is_private, "非公開にする場合はチェック", class: "form-check-label" %>
   </div>
-  <div>
-    <%= f.hidden_field :user_id, value: current_user.id %>
-  </div>
-  <div class="mb-3 d-grid gap-2">
+  <%= f.hidden_field :latitude, id: :lat %>
+  <%= f.hidden_field :longitude, id: :lng %>
+  <%= f.hidden_field :user_id, value: current_user.id %>
+  <div class="d-grid gap-2">
     <%= f.submit '保存', class: "btn btn-danger rounded-pill" %>
   </div>
 <% end %>

--- a/app/views/shared/_destination_form.html.erb
+++ b/app/views/shared/_destination_form.html.erb
@@ -3,15 +3,19 @@
     <%= f.label :name %>
     <%= f.text_field :name, id: :name, placeholder: "20文字以内", class: "form-control form-control-sm" %>
   </div>
-  <div class="mb-2">
+  <div class="mb-3">
     <%= f.label :address %>
     <%= f.text_field :address, id: :address_on_map, placeholder: "60文字以内", class: "form-control form-control-sm" %>
   </div>
-  <div class="mb-2">
-    <%= f.label :note %>
+  <div class="mb-3 d-flex align-items-center gap-1">
+    <%= f.label :category_id, "カテゴリー（任意）", class: "text-nowrap" %>
+    <%= f.collection_select(:category_id, Category.all, :id, :name, { prompt: "カテゴリーを選択" }, { class: "form-select form-select-sm" }) %>
+  </div>
+  <div class="mb-3">
+    <%= f.label :note, "メモ（任意）" %>
     <%= f.text_area :note, class: "form-control form-control-sm" %>
   </div>
-  <div class="mb-2 form-check">
+  <div class="mb-3 form-check">
     <%= f.check_box :is_private, {class: "form-check-input"}, "true", "false" %>
     <%= f.label :is_private, "非公開にする場合はチェック", class: "form-check-label" %>
   </div>

--- a/app/views/shared/_destination_form.html.erb
+++ b/app/views/shared/_destination_form.html.erb
@@ -1,11 +1,11 @@
 <%= form_with model: destination do |f| %>
   <div class="mb-2">
     <%= f.label :name %>
-    <%= f.text_field :name, id: :name, class: "form-control form-control-sm" %>
+    <%= f.text_field :name, id: :name, placeholder: "20文字以内", class: "form-control form-control-sm" %>
   </div>
   <div class="mb-2">
     <%= f.label :address %>
-    <%= f.text_field :address, id: :address_on_map, class: "form-control form-control-sm" %>
+    <%= f.text_field :address, id: :address_on_map, placeholder: "60文字以内", class: "form-control form-control-sm" %>
   </div>
   <div class="mb-2">
     <%= f.label :note %>

--- a/app/views/shared/_destination_form.html.erb
+++ b/app/views/shared/_destination_form.html.erb
@@ -4,6 +4,10 @@
     <%= f.text_field :name, id: :name, class: "form-control form-control-sm" %>
   </div>
   <div class="mb-2">
+    <%= f.label :address %>
+    <%= f.text_field :address, id: :address_on_map, class: "form-control form-control-sm" %>
+  </div>
+  <div class="mb-2">
     <%= f.label :note %>
     <%= f.text_area :note, class: "form-control form-control-sm" %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -32,7 +32,7 @@
 <div class="container-md mt-2">
   <div class="row">
     <div class="col-12 col-sm-5 px-0 pe-sm-2">
-      <div class="py-2 px-1 bg-white shadow-sm rounded-3">
+      <div class="my-groups py-2 px-1 bg-white shadow-sm rounded-3">
         <h6 class="fw-bold text-center">所属グループ</h6>
         <table>
           <% @groups.each do |group| %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,6 +25,7 @@ ja:
       destination:
         name: 場所の名前
         note: メモ
+        address: 住所
     models:
       user: ユーザー
       group: グループ

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -22,9 +22,13 @@ ja:
         prefecture_code: 都道府県
       group:
         name: グループ名
+      destination:
+        name: 場所の名前
+        note: メモ
     models:
       user: ユーザー
       group: グループ
+      destination: 行きたいところ
   devise:
     failure:
       already_authenticated: すでにログインしています。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   devise_for :users
   resources :users, only: :show
   resources :groups
+  resources :destinations
 end

--- a/db/migrate/20240923074025_create_destinations.rb
+++ b/db/migrate/20240923074025_create_destinations.rb
@@ -1,0 +1,14 @@
+class CreateDestinations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :destinations do |t|
+      t.string :name
+      t.text :note
+      t.float :latitude
+      t.float :longitude
+      t.references :user, null: false, foreign_key: true
+      t.boolean :is_private
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240927061316_add_address_to_destinations.rb
+++ b/db/migrate/20240927061316_add_address_to_destinations.rb
@@ -1,0 +1,5 @@
+class AddAddressToDestinations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :destinations, :address, :string
+  end
+end

--- a/db/migrate/20240929042342_create_categories.rb
+++ b/db/migrate/20240929042342_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240929042638_add_category_id_to_destinations.rb
+++ b/db/migrate/20240929042638_add_category_id_to_destinations.rb
@@ -1,0 +1,5 @@
+class AddCategoryIdToDestinations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :destinations, :category_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_09_23_074025) do
+ActiveRecord::Schema.define(version: 2024_09_27_061316) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2024_09_23_074025) do
     t.boolean "is_private"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "address"
     t.index ["user_id"], name: "index_destinations_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_09_15_090346) do
+ActiveRecord::Schema.define(version: 2024_09_23_074025) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -38,6 +38,18 @@ ActiveRecord::Schema.define(version: 2024_09_15_090346) do
     t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "destinations", force: :cascade do |t|
+    t.string "name"
+    t.text "note"
+    t.float "latitude"
+    t.float "longitude"
+    t.integer "user_id", null: false
+    t.boolean "is_private"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_destinations_on_user_id"
   end
 
   create_table "group_users", force: :cascade do |t|
@@ -75,6 +87,7 @@ ActiveRecord::Schema.define(version: 2024_09_15_090346) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "destinations", "users"
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_09_27_061316) do
+ActiveRecord::Schema.define(version: 2024_09_29_042638) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -40,6 +40,12 @@ ActiveRecord::Schema.define(version: 2024_09_27_061316) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "destinations", force: :cascade do |t|
     t.string "name"
     t.text "note"
@@ -50,6 +56,7 @@ ActiveRecord::Schema.define(version: 2024_09_27_061316) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "address"
+    t.integer "category_id"
     t.index ["user_id"], name: "index_destinations_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,4 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+categories = ["グルメ", "ショッピング", "遊ぶ・体験", "宿泊・温泉", "歴史", "自然・レジャー", "子どもと行きたい", "写真スポット", "その他"]
+categories.each do |category_name|
+  Category.find_or_create_by(name: category_name)
+end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :category do
+    name { "その他" }
+  end
+end

--- a/spec/factories/destinations.rb
+++ b/spec/factories/destinations.rb
@@ -1,10 +1,8 @@
 FactoryBot.define do
   factory :destination do
-    name { "MyString" }
-    note { "MyText" }
+    name { "example" }
+    address { "example_city" }
     latitude { 1.5 }
     longitude { 1.5 }
-    user { nil }
-    is_private { false }
   end
 end

--- a/spec/factories/destinations.rb
+++ b/spec/factories/destinations.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :destination do
+    name { "MyString" }
+    note { "MyText" }
+    latitude { 1.5 }
+    longitude { 1.5 }
+    user { nil }
+    is_private { false }
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  let(:user) { create(:user) }
+  let(:category) { create(:category) }
+  let(:destination) { create(:destination, category: category, user: user) }
+
+  describe "リレーションに関するテスト" do
+    it "Destinationモデルと関連付いていること" do
+      expect(category.destinations).to include(destination)
+    end
+  end
+end

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Destination, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -1,5 +1,72 @@
 require 'rails_helper'
 
 RSpec.describe Destination, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:category) { create(:category) }
+  let(:destination) { create(:destination, category: category, user: user) }
+
+  describe "バリデーションに関するテスト" do
+    context "name" do
+      it "入力されていない場合、エラーになること" do
+        destination.name = nil
+        expect(destination).to be_invalid
+        expect(destination.errors.full_messages).to include("場所の名前、住所は空欄にできません")
+      end
+
+      it "20文字以内の場合、有効" do
+        destination.name = "a" * 20
+        expect(destination).to be_valid
+      end
+
+      it "20文字以上の場合、エラーになること" do
+        destination.name = "a" * 21
+        expect(destination).to be_invalid
+        expect(destination.errors.full_messages).to include("場所の名前は20文字以内で入力してください")
+      end
+    end
+
+    context "address" do
+      it "入力されていない場合、エラーになること" do
+        destination.address = nil
+        expect(destination).to be_invalid
+        expect(destination.errors.full_messages).to include("場所の名前、住所は空欄にできません")
+      end
+
+      it "60文字以内の場合、有効" do
+        destination.address = "a" * 60
+        expect(destination).to be_valid
+      end
+
+      it "60文字以上の場合、エラーになること" do
+        destination.address = "a" * 61
+        expect(destination).to be_invalid
+        expect(destination.errors.full_messages).to include("住所は60文字以内で入力してください")
+      end
+    end
+
+    context "緯度・経度" do
+      it "入力されていない場合、エラーになること" do
+        destination.latitude = nil
+        destination.longitude = nil
+        expect(destination).to be_invalid
+        expect(destination.errors.full_messages).to include("場所の名前、住所は空欄にできません")
+      end
+
+      it "入力済みの場合、有効" do
+        destination.latitude = 1.5
+        destination.longitude = 1.5
+        expect(destination).to be_valid
+      end
+    end
+  end
+
+  describe "リレーションに関するテスト" do
+    it "Userモデルと関連付いていること" do
+      expect(destination.user_id).to eq user.id
+    end
+
+    it "Categoryモデルと関連付いていること" do
+      expect(destination.category_id).to eq category.id
+    end
+  end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -3,24 +3,20 @@ require 'rails_helper'
 RSpec.describe Group, type: :model do
   let(:group) { create(:group) }
 
-  describe "グループ名" do
-    context "入力されていない場合" do
-      it "エラーになること" do
+  describe "バリデーションに関するテスト" do
+    context "グループ名" do
+      it "入力されていない場合、エラーになること" do
         group.name = nil
         expect(group).to be_invalid
         expect(group.errors.full_messages).to include("グループ名を入力してください")
       end
-    end
 
-    context "15文字以下の場合" do
-      it "有効であること" do
+      it "15文字以内の場合、有効" do
         group.name = "a" * 15
         expect(group).to be_valid
       end
-    end
 
-    context "16文字以上の場合" do
-      it "エラーになること" do
+      it "16文字以上の場合、エラーになること" do
         group.name = "a" * 16
         expect(group).to be_invalid
         expect(group.errors.full_messages).to include("グループ名は15文字以内で入力してください")

--- a/spec/models/group_user_spec.rb
+++ b/spec/models/group_user_spec.rb
@@ -3,17 +3,19 @@ require 'rails_helper'
 RSpec.describe GroupUser, type: :model do
   let(:group_user) { create(:group_user) }
 
-  it "user_idとgroup_idが両方存在する場合、有効であること" do
-    expect(group_user).to be_valid
-  end
+  describe "リレーションに関するテスト" do
+    it "user_idが無い場合、エラーになること" do
+      group_user.user_id = nil
+      expect(group_user).to be_invalid
+    end
 
-  it "user_idが無い場合、無効であること" do
-    group_user.user_id = nil
-    expect(group_user).to be_invalid
-  end
+    it "group_idが無い場合、エラーになること" do
+      group_user.group_id = nil
+      expect(group_user).to be_invalid
+    end
 
-  it "group_idが無い場合、無効であること" do
-    group_user.group_id = nil
-    expect(group_user).to be_invalid
+    it "user_idとgroup_idが両方存在する場合、有効" do
+      expect(group_user).to be_valid
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,48 +3,38 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   let(:user) { create(:user) }
 
-  describe "ユーザー名" do
-    context "入力されていない場合" do
-      it "エラーになること" do
+  describe "バリデーションに関するテスト" do
+    context "ユーザー名" do
+      it "入力されていない場合、エラーになること" do
         user.name = nil
         expect(user).to be_invalid
         expect(user.errors.full_messages).to include("お名前を入力してください")
       end
-    end
 
-    context "15文字以下の場合" do
-      it "有効であること" do
+      it "15文字以内の場合、有効" do
         user.name = "a" * 15
         expect(user).to be_valid
       end
-    end
 
-    context "16文字以上の場合" do
-      it "エラーになること" do
+      it "16文字以上の場合、エラーになること" do
         user.name = "a" * 16
         expect(user).to be_invalid
         expect(user.errors.full_messages).to include("お名前は15文字以内で入力してください")
       end
     end
-  end
 
-  describe "自己紹介" do
-    context "入力されていない場合" do
-      it "有効であること" do
+    context "自己紹介" do
+      it "入力されていない場合、有効" do
         user.introduction = nil
         expect(user).to be_valid
       end
-    end
 
-    context "80文字以下の場合" do
-      it "有効であること" do
+      it "80文字以内の場合、有効" do
         user.introduction = "a" * 80
         expect(user).to be_valid
       end
-    end
 
-    context "81文字以上の場合" do
-      it "エラーになること" do
+      it "81文字以上の場合、エラーになること" do
         user.introduction = "a" * 81
         expect(user).to be_invalid
         expect(user.errors.full_messages).to include("自己紹介は80文字以内で入力してください")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,6 +64,6 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
   config.before(:each, type: :system) do
-    driven_by :rack_test
+    driven_by :selenium_chrome
   end
 end

--- a/spec/system/categories_spec.rb
+++ b/spec/system/categories_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe "Categories", type: :system do
+  let(:user) { create(:user) }
+  let(:category) { create(:category) }
+  let!(:destination) { create(:destination, name: "東京タワー", category: category, user: user) }
+  let!(:destination_tako) { create(:destination, name: "たこ焼き屋", user: user) }
+
+  before do
+    visit new_user_session_path
+    fill_in "メールアドレス", with: user.email
+    fill_in "パスワード", with: user.password
+    click_button "ログイン"
+  end
+
+  it "選択したカテゴリーで一覧を絞り込めること" do
+    visit destinations_path
+    select "その他", from: "category_id"
+    click_button "絞り込む"
+
+    expect(current_path).to eq destinations_path
+    within '.destinations-table' do
+      expect(page).to have_content("東京タワー")
+      expect(page).not_to have_content("たこ焼き屋")
+    end
+  end
+end

--- a/spec/system/destinations_spec.rb
+++ b/spec/system/destinations_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Destinations", type: :system do
       fill_in "destination[address]", with: ""
       click_button "保存"
 
-      expect(page).to have_content "地図で場所を検索してください"
+      expect(page).to have_content "Googleマップで場所を検索してください。一部項目が自動入力されます。（編集可）"
     end
 
     it "必須項目が入力されている場合、有効" do

--- a/spec/system/destinations_spec.rb
+++ b/spec/system/destinations_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe "Destinations", type: :system do
+  let(:user) { create(:user) }
+  let(:category) { create(:category) }
+  let(:destination) { create(:destination, category: category, user: user) }
+
+  before do
+    visit new_user_session_path
+    fill_in "メールアドレス", with: user.email
+    fill_in "パスワード", with: user.password
+    click_button "ログイン"
+  end
+
+  describe "新規作成" do
+    it "必須項目が入力されている場合、登録ができること" do
+      visit new_destination_path
+      fill_in "destination[name]", with: "東京タワー"
+      fill_in "destination[address]", with: "日本、〒105-0011 東京都港区芝公園４丁目２−８"
+      execute_script("document.getElementById('lat').value = 35.6585805;")
+      execute_script("document.getElementById('lng').value = 139.7454329;")
+      click_button "保存"
+
+      expect(current_path).to eq destinations_path
+      within '.destinations-table' do
+        expect(page).to have_content("東京タワー")
+      end
+    end
+
+    it "入力に不備がある場合、登録に失敗すること" do
+      visit new_destination_path
+      fill_in "destination[name]", with: ""
+      fill_in "destination[address]", with: ""
+      click_button "保存"
+
+      expect(page).to have_content "地図で場所を検索してください"
+    end
+  end
+
+  describe "編集" do
+    it "更新できること" do
+      visit edit_destination_path(destination.id)
+      fill_in "destination[name]", with: "update"
+      click_button "保存"
+
+      expect(current_path).to eq destinations_path
+      expect(page).to have_content "「update」を更新しました。"
+      within '.destinations-table' do
+        expect(page).to have_content("update")
+      end
+    end
+
+    it "削除できること" do
+      visit destination_path(destination.id)
+      click_link "削除"
+      page.accept_confirm
+
+      expect(current_path).to eq destinations_path
+      expect(page).to have_content "行きたいところリストから「example」を削除しました。"
+      within '.destinations-table' do
+        expect(page).not_to have_content("example")
+      end
+    end
+  end
+end

--- a/spec/system/destinations_spec.rb
+++ b/spec/system/destinations_spec.rb
@@ -13,7 +13,16 @@ RSpec.describe "Destinations", type: :system do
   end
 
   describe "新規作成" do
-    it "必須項目が入力されている場合、登録ができること" do
+    it "入力に不備がある場合、エラーになること" do
+      visit new_destination_path
+      fill_in "destination[name]", with: ""
+      fill_in "destination[address]", with: ""
+      click_button "保存"
+
+      expect(page).to have_content "地図で場所を検索してください"
+    end
+
+    it "必須項目が入力されている場合、有効" do
       visit new_destination_path
       fill_in "destination[name]", with: "東京タワー"
       fill_in "destination[address]", with: "日本、〒105-0011 東京都港区芝公園４丁目２−８"
@@ -25,15 +34,6 @@ RSpec.describe "Destinations", type: :system do
       within '.destinations-table' do
         expect(page).to have_content("東京タワー")
       end
-    end
-
-    it "入力に不備がある場合、登録に失敗すること" do
-      visit new_destination_path
-      fill_in "destination[name]", with: ""
-      fill_in "destination[address]", with: ""
-      click_button "保存"
-
-      expect(page).to have_content "地図で場所を検索してください"
     end
   end
 

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -29,31 +29,37 @@ RSpec.describe "Groups", type: :system do
         check "another_user"
         click_button "作成"
         expect(current_path).to eq user_path(user.id)
-        expect(page).to have_content "グループを登録しました"
-        expect(page).to have_content "テストグループ"
+        expect(page).to have_content "「テストグループ」を登録しました"
+        within '.my-groups' do
+          expect(page).to have_content "テストグループ"
+        end
       end
     end
   end
 
   describe "グループ編集" do
+    let(:group) { create(:group, name: "テストグループ") }
+
     it "更新できること" do
-      group = Group.last # 先のテストで登録したグループを取得
       visit edit_group_path(group.id)
       fill_in "グループ名", with: "update"
       check "another_user"
       click_button "変更"
       expect(current_path).to eq user_path(user.id)
-      expect(page).to have_content "グループを更新しました"
-      expect(page).to have_content "update"
+      expect(page).to have_content "「update」を更新しました"
+      within '.my-groups' do
+        expect(page).to have_content "update"
+      end
     end
 
     it "削除できること" do
-      group = Group.last # 先のテストで登録したグループを取得
       visit group_path(group.id)
       click_link "グループを削除"
       expect(current_path).to eq user_path(user.id)
-      expect(page).to have_content "グループを削除しました"
-      expect(page).not_to have_content "update"
+      expect(page).to have_content "「テストグループ」を削除しました"
+      within '.my-groups' do
+        expect(page).not_to have_content "テストグループ"
+      end
     end
   end
 end

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe "Groups", type: :system do
     it "削除できること" do
       visit group_path(group.id)
       click_link "グループを削除"
+      page.accept_confirm
       expect(current_path).to eq user_path(user.id)
       expect(page).to have_content "「テストグループ」を削除しました"
       within '.my-groups' do

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -12,27 +12,23 @@ RSpec.describe "Groups", type: :system do
   end
 
   describe "グループ作成" do
-    context "グループ名が入力されていない場合" do
-      it "作成に失敗すること" do
-        visit new_group_path
-        fill_in "グループ名", with: ""
-        check "another_user"
-        click_button "作成"
-        expect(page).to have_content "グループの登録に失敗しました"
-      end
+    it "グループ名が入力されていない場合、エラーになること" do
+      visit new_group_path
+      fill_in "グループ名", with: ""
+      check "another_user"
+      click_button "作成"
+      expect(page).to have_content "グループの登録に失敗しました"
     end
 
-    context "グループ名が入力されている場合" do
-      it "作成に成功すること" do
-        visit new_group_path
-        fill_in "グループ名", with: "テストグループ"
-        check "another_user"
-        click_button "作成"
-        expect(current_path).to eq user_path(user.id)
-        expect(page).to have_content "「テストグループ」を登録しました"
-        within '.my-groups' do
-          expect(page).to have_content "テストグループ"
-        end
+    it "グループ名が入力されている場合、有効" do
+      visit new_group_path
+      fill_in "グループ名", with: "テストグループ"
+      check "another_user"
+      click_button "作成"
+      expect(current_path).to eq user_path(user.id)
+      expect(page).to have_content "「テストグループ」を登録しました"
+      within '.my-groups' do
+        expect(page).to have_content "テストグループ"
       end
     end
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -2,58 +2,50 @@ require 'rails_helper'
 
 RSpec.describe "Users", type: :system do
   describe "新規登録" do
-    context "必須項目が入力されている場合" do
-      it "ユーザー登録が成功すること" do
-        visit new_user_registration_path
-        fill_in "お名前", with: "テストユーザー"
-        fill_in "メールアドレス", with: "test@test.com"
-        fill_in "パスワード", with: "password"
-        fill_in "パスワード（確認用）", with: "password"
-        click_button "新規登録"
-
-        user = User.last # 登録したユーザーを取得
-        expect(current_path).to eq user_path(user.id)
-        expect(page).to have_content "アカウント登録が完了しました。"
-      end
+    it "入力に不備がある場合、エラーになること" do
+      visit new_user_registration_path
+      fill_in "お名前", with: ""
+      fill_in "メールアドレス", with: ""
+      fill_in "パスワード", with: ""
+      fill_in "パスワード（確認用）", with: ""
+      click_button "新規登録"
+      expect(page).to have_content("お名前を入力してください")
+      expect(page).to have_content("メールアドレスを入力してください")
+      expect(page).to have_content("パスワードを入力してください")
     end
 
-    context "入力に不備がある場合" do
-      it "ユーザー登録が失敗すること" do
-        visit new_user_registration_path
-        fill_in "お名前", with: ""
-        fill_in "メールアドレス", with: ""
-        fill_in "パスワード", with: ""
-        fill_in "パスワード（確認用）", with: ""
-        click_button "新規登録"
-        expect(page).to have_content("お名前を入力してください")
-        expect(page).to have_content("メールアドレスを入力してください")
-        expect(page).to have_content("パスワードを入力してください")
-      end
+    it "必須項目が入力されている場合、有効" do
+      visit new_user_registration_path
+      fill_in "お名前", with: "テストユーザー"
+      fill_in "メールアドレス", with: "test@test.com"
+      fill_in "パスワード", with: "password"
+      fill_in "パスワード（確認用）", with: "password"
+      click_button "新規登録"
+
+      user = User.last # 登録したユーザーを取得
+      expect(current_path).to eq user_path(user.id)
+      expect(page).to have_content "アカウント登録が完了しました。"
     end
   end
 
   describe "ログイン" do
     let(:user) { create(:user) }
 
-    context "認証情報が正しい場合" do
-      it "ログインできること" do
-        visit new_user_session_path
-        fill_in "メールアドレス", with: user.email
-        fill_in "パスワード", with: user.password
-        click_button "ログイン"
-        expect(current_path).to eq user_path(user.id)
-        expect(page).to have_content "ログインしました。"
-      end
+    it "認証情報に誤りがある場合、エラーになること" do
+      visit new_user_session_path
+      fill_in "メールアドレス", with: user.email
+      fill_in "パスワード", with: "missPassword"
+      click_button "ログイン"
+      expect(page).to have_content "メールアドレスまたはパスワードが違います。"
     end
 
-    context "認証情報に誤りがある場合" do
-      it "ログインに失敗すること" do
-        visit new_user_session_path
-        fill_in "メールアドレス", with: user.email
-        fill_in "パスワード", with: "missPassword"
-        click_button "ログイン"
-        expect(page).to have_content "メールアドレスまたはパスワードが違います。"
-      end
+    it "認証情報が正しい場合、有効" do
+      visit new_user_session_path
+      fill_in "メールアドレス", with: user.email
+      fill_in "パスワード", with: user.password
+      click_button "ログイン"
+      expect(current_path).to eq user_path(user.id)
+      expect(page).to have_content "ログインしました。"
     end
   end
 end


### PR DESCRIPTION
ユーザーに紐づいた行きたいリストの登録・編集機能を実装

- 行きたいリスト投稿のCRUD処理
- Google Maps APIを活用
  - 地図上に複数マーカーを一覧表示
  - 地図上のマーカーをクリックで詳細を表示
  - new, edit画面でマーカーを動かすと地点の微調整が可能
- 行きたいリストのカテゴリ分け、一覧の絞り込み機能

以上、ご確認の程よろしくお願いいたします。